### PR TITLE
Target Java 1.8

### DIFF
--- a/asn1-datatypes/pom.xml
+++ b/asn1-datatypes/pom.xml
@@ -9,8 +9,8 @@
     <inceptionYear>2015</inceptionYear> 
     
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/asn1-uper/pom.xml
+++ b/asn1-uper/pom.xml
@@ -9,8 +9,8 @@
     <inceptionYear>2015</inceptionYear>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Build with JDK 21 fails with the following.

<pre>
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] Source option 7 is no longer supported. Use 8 or later.
[ERROR] Target option 7 is no longer supported. Use 8 or later.
[INFO] 2 errors
</pre>

`source`/`target` 1.7 has been deprecated since Java 20. I went with the conservative change of simply changing the `source` and `target` values. I think it would be preferable to also switch to `release` property instead of `source` and `target`, but that would need a bit more boilerplate in POM - inclusion of a more recent compiler plugin. Let me know if that is desirable.