### PR TITLE
Move logback to test scope

### DIFF
--- a/asn1-uper/pom.xml
+++ b/asn1-uper/pom.xml
@@ -79,9 +79,15 @@
             <version>0.6.1</version>
         </dependency>
         <dependency>
+        	<groupId>org.slf4j</groupId>
+        	<artifactId>slf4j-api</artifactId>
+        	<version>2.0.17</version>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.5.20</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
It's great that slf4j is used, but it's not good that a library drags in a logging backend (logback-classic and logback-core artifacts) as a transitive dependency into projects using it. It creates bloat in the client project, might raise questions during security audits (why an unused logging framework is part of the project), etc.

Logback has also been upgraded to the latest version. I assumed this should not be a problem and did not bother separating scope change and version upgrade into separate commits. Let me know otherwise.

As an aside, I'm not a fan of DEBUG log level being enabled by default, which is the case for Logback when not configured explicitly. The debug log is useful when troubleshooting a failing test case, but when all test cases are passing (the typical case), debug logging just creates noise in build output possibly drowning out something more important. In a simple case like this I would opt for the more lightweight slf4j-simple instead of a full-blown logging framework, debug level could be enabled via a system property when actually needed. Alternatively, Logback configuration could be added to disable debug level by default. Either approach could be the subject of a separate PR, if desired.