### PR TITLE
Add support for extensible enum decoding

### DIFF
--- a/asn1-uper/src/test/java/net/gcdc/asn1/uper/EnumCoderTest.java
+++ b/asn1-uper/src/test/java/net/gcdc/asn1/uper/EnumCoderTest.java
@@ -1,0 +1,37 @@
+package net.gcdc.asn1.uper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import net.gcdc.asn1.datatypes.HasExtensionMarker;
+
+public class EnumCoderTest {
+    @HasExtensionMarker
+    private enum ConstructedType {
+        CHOICE(1), SEQUENCE(2), SET(3), SEQUENCE_OF(4), SET_OF(5);
+
+        private final int value;
+
+        private ConstructedType(int value) {
+            this.value = value;
+        }
+    }
+
+    @Test
+    public void extensibleNoExt() {
+        assertEquals(ConstructedType.SEQUENCE,
+                UperEncoder.decode(new byte[] {0x10}, ConstructedType.class));
+    }
+
+    @Test
+    public void extensibleExtSmall() {
+        assertNull(UperEncoder.decode(new byte[] {(byte) 0xA9}, ConstructedType.class));
+    }
+
+    @Test
+    public void extensibleWithLength() {
+        assertNull(UperEncoder.decode(new byte[] {(byte) 0xC0, 0x50, 0x00}, ConstructedType.class));
+    }
+}


### PR DESCRIPTION
Trying to decode an `enum` with a `@HasExtensionMarker` annotation fails with the following error.

<pre>
java.lang.UnsupportedOperationException: choice extension is not implemented yet
	at net.gcdc.asn1.uper.EnumCoder.decode(EnumCoder.java:71)
	at net.gcdc.asn1.uper.UperEncoder.decode2(UperEncoder.java:86)
	at net.gcdc.asn1.uper.UperEncoder.decode(UperEncoder.java:61)
	at net.gcdc.asn1.uper.EnumCoderTest.extensibleExtSmall(EnumCoderTest.java:30)
</pre>

A couple caveats apply to the proposed change:
- only decoding is supported, but not encoding;
- an extended enum is returned as `null`.

Due to the second point above, if a protocol used an extensible optional enum, it would be impossible to tell whether an extended value was encoded or the optional enum was not encoded at all. Anyway, that is in my opinion better than not being able to decode such messages at all. And for protocols that do not use extensible enums there is no impact.

Another point to take care of is version change. If the project followed [semver](https://semver.org/) and used [Maven Release Plugin](https://maven.apache.org/maven-release/maven-release-plugin/) (snapshot versions), I would change the version to 1.2.0-SNAPSHOT, but I don't know what the versioning policy is.